### PR TITLE
Update gem dependency versions

### DIFF
--- a/check_and_notify.gemspec
+++ b/check_and_notify.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-nav", "~> 0.2.4"
+  spec.add_development_dependency "httparty", "~> 0.15.6"
 end

--- a/check_and_notify.gemspec
+++ b/check_and_notify.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.2', '>= 4.2.0'
-  spec.add_dependency "sidekiq", "5.0.4"
+  spec.add_runtime_dependency "activesupport", ">= 4.2.0"
+  spec.add_dependency "sidekiq"
   spec.add_dependency "sidekiq-cron", "0.6.3"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
* Remove the `activesupport` version restriction `< 5.0`.
* Remove the `sidekiq` version all together.
* Add `httparty` to dependencies to make the tests pass.